### PR TITLE
Update libssmt.cpp

### DIFF
--- a/Common/LibSSMT/libssmt.cpp
+++ b/Common/LibSSMT/libssmt.cpp
@@ -26,7 +26,7 @@
 #endif
 #include <drift/dslcore.h>
 #include <drift/GenLib.h>
-#include <drift/Buffer.h>
+#include <drift/buffer.h>
 #include "libssmt.h"
 
 #define SSMT_MAJOR 1


### PR DESCRIPTION
drift/buffer.h is under case in "RadioBot/Common/DSL/dslsrc/drift" during build process, causes build to error

`/home/kaliwolf/tmp/RadioBot/Common/LibSSMT/libssmt.cpp:29:10: fatal error: drift/Buffer.h: No such file or directory
   29 | #include <drift/Buffer.h>
      |          ^~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [Common/LibSSMT/CMakeFiles/ssmt.dir/build.make:76: Common/LibSSMT/CMakeFiles/ssmt.dir/libssmt.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1402: Common/LibSSMT/CMakeFiles/ssmt.dir/all] Error 2
make: *** [Makefile:91: all] Error 2`

Changing this variable allowed me to continue compiling on Ubuntu 24.04